### PR TITLE
Revert "maple: extract: Don't add Sony camera service to camera-daemo…

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -89,10 +89,4 @@ fix_product_path product/etc/permissions/lpa.xml
 fix_product_path product/etc/permissions/qcrilhook.xml
 fix_product_path product/etc/permissions/telephonyservice.xml
 
-#
-# Don't add Sony camera service to camera-daemon tasks
-#
-
-sed -i 's/\/dev\/cpuset\/camera-daemon\/tasks //g' "${DEVICE_ROOT}"/vendor/etc/init/vendor.somc.hardware.camera.provider@1.0-service.rc
-
 "${MY_DIR}"/setup-makefiles.sh


### PR DESCRIPTION
…n tasks"

Turns out, this was not the problem with stuck cpu frequencies. We can actually make use of this now.

This reverts commit be3a5a909c90f81dbf2a3cbef73ca4e54f9fb98f.