### PR TITLE
maple: Enable split build properties

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -42,6 +42,8 @@ TARGET_SCREEN_DENSITY := 480
 DEVICE_MANIFEST_FILE += $(DEVICE_PATH)/manifest.xml
 
 ### PROPS
+# Split build properties
+BOARD_PROPERTY_OVERRIDES_SPLIT_ENABLED := true
 # Add device-specific ones
 TARGET_SYSTEM_PROP += $(DEVICE_PATH)/system.prop
 TARGET_VENDOR_PROP += $(DEVICE_PATH)/vendor.prop


### PR DESCRIPTION
This was taken out of yoshino-common since it defaults to true for lilac and poplar - they were launched with O.

Since maple was launched with N and doesn't have full treble support, we need to import it again here or we loose all our vendor props.