### PR TITLE
maple: Enable vowifi for some of turkish carriers

### DIFF
--- a/config/modem/432/modem.conf
+++ b/config/modem/432/modem.conf
@@ -1,1 +1,1 @@
-vodafone_turkey_ims
+vodafone_turkey_volte_vowifi

--- a/config/modem/433/modem.conf
+++ b/config/modem/433/modem.conf
@@ -1,1 +1,1 @@
-turkcell_turkey_ims
+turkcell_turkey_volte_vowifi

--- a/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
+++ b/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
@@ -438,7 +438,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="2" />
     </carrier_config>
 
-     <!-- Carrier-specific customized TR -->
+    <!-- Carrier-specific customized TR -->
     <carrier_config mcc="286" mnc="01">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="true" />

--- a/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
+++ b/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
@@ -438,12 +438,18 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.-->
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="2" />
     </carrier_config>
 
-    <!-- Carrier-specific customized TR -->
+     <!-- Carrier-specific customized TR -->
     <carrier_config mcc="286" mnc="01">
         <boolean name="carrier_volte_available_bool" value="true" />
+        <boolean name="carrier_wfc_ims_available_bool" value="true" />
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+        <int name="carrier_default_wfc_ims_roaming_mode_int" value="2" />
     </carrier_config>
     <carrier_config mcc="286" mnc="02">
         <boolean name="carrier_volte_available_bool" value="true" />
+        <boolean name="carrier_wfc_ims_available_bool" value="true" />
+        <int name="carrier_default_wfc_ims_mode_int" value="1" />
+        <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
     </carrier_config>
     <carrier_config mcc="286" mnc="03">
         <boolean name="carrier_volte_available_bool" value="true" />


### PR DESCRIPTION
Stock fw comes with vowifi enabled modem configurations for two supported turkish operators but never activated in oem configuration updated modem.conf and also required carrier_config settings imported from poplar